### PR TITLE
Small fixes to manpages

### DIFF
--- a/man/powermanga.fr.6
+++ b/man/powermanga.fr.6
@@ -145,4 +145,4 @@ ou modidier selon les termes de GNU General Public License. Voir
 .I /usr/share/doc/powermanga/copyright
 pour plus de détails.
 .br
-Cette page de manuel a été rédigée par Jeronimo Pellegrini <pellegrini@mpcnet.com.br>, sur la base de la précédente par Sam Hocevar <sam@zoy.org>, pour le système Debian GNU/Linux (mais peut être utilisée par d'autres).
+Cette page de manuel a été rédigée par Jeronimo Pellegrini <j_p@aleph0.info>, sur la base de la précédente par Sam Hocevar <sam@zoy.org>, pour le système Debian GNU/Linux (mais peut être utilisée par d'autres).

--- a/powermanga.6
+++ b/powermanga.6
@@ -15,7 +15,7 @@ The options are, from the bottom to the top:
 - More speed
 .TP
 - More energy to your ship
-If you get out of energy, you lose your ship. Losing your ship means either going back to the ship you were using before you "upgraded' it, or dying if you had no previous ship! You can check your energy level in the little bar at the bottom (the bar at the right is yours; the one at the left is your enemy's, in case you're fighting a big one)
+If you get out of energy, you lose your ship. Losing your ship means either going back to the ship you were using before you "upgraded" it, or dying if you had no previous ship! You can check your energy level in the little bar at the bottom (the bar at the right is yours; the one at the left is your enemy's, in case you're fighting a big one)
 .TP
 - Several options for different weapons
 .TP
@@ -143,4 +143,4 @@ and/or change it under the terms of the GNU General Public License. See the
 .I /usr/share/doc/powermanga/copyright
 for details.
 .br
-This manual page was written by Jeronimo Pellegrini <pellegrini@mpcnet.com.br>, based on the previous one by Sam Hocevar <sam@zoy.org>, for the Debian GNU/Linux system (but may be used by others).
+This manual page was written by Jeronimo Pellegrini <j_p@aleph0.info>, based on the previous one by Sam Hocevar <sam@zoy.org>, for the Debian GNU/Linux system (but may be used by others).


### PR DESCRIPTION
Hello,

I have written the manpage for Powermanga some decades ago :-) and only now I realized it has a small typo. This PR also updates my email in the manpage (the old one doesn't exist anymore)...

* A double-quote was closed with a single-quote. This messed up
syntax highliting in editors.

* Update the email of the original author of the manpage (me).