### PR TITLE
disable default executable stack with i586 builds

### DIFF
--- a/src/assembler.S
+++ b/src/assembler.S
@@ -2076,3 +2076,8 @@ _et_col1:       .int 0    #11
 _et_col2:       .int 0    #13
 #_et_col1:       .byte 11
 #_et_col2:       .byte 13
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif
+

--- a/src/assembler_opt.S
+++ b/src/assembler_opt.S
@@ -407,3 +407,6 @@ _COPY2X32BITS_512x440:
     leave
     ret
 
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/src/config_file.c
+++ b/src/config_file.c
@@ -293,6 +293,14 @@ configfile_load (void)
     {
       power_conf->verbose = 0;
     }
+  if (!lisp_read_int (lst, "difficulty", &power_conf->difficulty))
+    {
+      power_conf->difficulty = 1;
+    }
+  if (power_conf->difficulty < 0 || power_conf->difficulty > 2)
+    {
+      power_conf->difficulty = 1;
+    }
   if (!lisp_read_int (lst, "scale_x", &power_conf->scale_x))
     {
       power_conf->scale_x = 2;


### PR DESCRIPTION
Fixes #2 